### PR TITLE
Disabled curl Expect Logic

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,39 @@
+Version 0.15.0
+---------------------------------------------------------------------------
+
+Security fixes:
+
+* [CVE-2019-13038] Redirect URL validation bypass
+
+  Version 0.14.1 and older of mod_auth_mellon allows the redirect URL
+  validation to be bypassed by specifying an URL formatted as
+  "http:www.hostname.com". In this case, the APR parsing utility
+  would parse the scheme as http, host as NULL and path as www.hostname.com.
+  Browsers, however, interpret the URL differently and redirect to
+  www.hostname.com. This could be reproduced with:
+     https://application.com/mellon/login?ReturnTo=http:www.hostname.com
+
+  This version fixes that issue by rejecting all URLs with
+  scheme, but no host name.
+
+Enhancements:
+
+ * A XSLT script that allows converting attribute maps from Shibboleth
+   to a set of MellonSetEnvNoPrefix entries was added. The script can
+   be found at doc/mellon-attribute-map.xsl
+
+ * A new configuration option MellonEnvPrefix was added. This option allows
+   you to configure the variable prefix, which normally defaults to MELLON_
+
+ * A new configuration option MellonAuthnContextComparisonType was added.
+   This option allows you to set the "Comparison" attribute within
+   the AuthnRequest
+
+Notable bug fixes:
+
+  * Compilation issues on Solaris were fixed
+
+
 Version 0.14.2
 ---------------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -893,9 +893,10 @@ There's a mailing list for discussion and support.
 ## Reporting security vulnerabilities
 
 For reporting security vulnerabilities in mod_auth_mellon, please contact
-the maintainer directly at the following email address:
+the maintainers directly at the following email address:
 
-  olav.morken@uninett.no
+  jhrozek@redhat.com
+  simo@redhat.com
 
 This allows us to coordinate the disclosure of the vulnerability with the
 fixes for the vulnerability.

--- a/auth_mellon_cache.c
+++ b/auth_mellon_cache.c
@@ -235,7 +235,8 @@ static int am_cache_entry_store_string(am_cache_entry_t *entry,
 
     if (am_cache_entry_pool_left(entry) < str_len) {
         ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL,
-                     "apr_cache_entry_store_string() asked %zd available: %zd. "
+                     "apr_cache_entry_store_string() asked %" APR_SIZE_T_FMT
+                     " available: %" APR_SIZE_T_FMT ". "
                      "It may be a good idea to increase MellonCacheEntrySize.",
                      str_len, am_cache_entry_pool_left(entry));
         return HTTP_INTERNAL_SERVER_ERROR;

--- a/auth_mellon_util.c
+++ b/auth_mellon_util.c
@@ -116,6 +116,10 @@ int am_validate_redirect_url(request_rec *r, const char *url)
 
     /* Sanity check of the scheme of the domain. We only allow http and https. */
     if (uri.scheme) {
+        /* http and https schemes without hostname are invalid. */
+        if (!uri.hostname) {
+            return HTTP_BAD_REQUEST;
+        }
         if (strcasecmp(uri.scheme, "http")
             && strcasecmp(uri.scheme, "https")) {
             AM_LOG_RERROR(APLOG_MARK, APLOG_ERR, 0, r,

--- a/auth_mellon_util.c
+++ b/auth_mellon_util.c
@@ -118,6 +118,9 @@ int am_validate_redirect_url(request_rec *r, const char *url)
     if (uri.scheme) {
         /* http and https schemes without hostname are invalid. */
         if (!uri.hostname) {
+            AM_LOG_RERROR(APLOG_MARK, APLOG_ERR, 0, r,
+                          "Preventing redirect with scheme but no hostname: %s",
+                          url);
             return HTTP_BAD_REQUEST;
         }
         if (strcasecmp(uri.scheme, "http")

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([mod_auth_mellon],[0.14.2],[https://github.com/latchset/mod_auth_mellon/issues])
+AC_INIT([mod_auth_mellon],[0.15.0],[https://github.com/latchset/mod_auth_mellon/issues])
 AC_CONFIG_HEADERS([config.h])
 
 # We require support for C99.

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([mod_auth_mellon],[0.14.2],[olav.morken@uninett.no])
+AC_INIT([mod_auth_mellon],[0.14.2],[https://github.com/latchset/mod_auth_mellon/issues])
 AC_CONFIG_HEADERS([config.h])
 
 # We require support for C99.


### PR DESCRIPTION
By default, curl will add the Expect Header and will wait for 1 sec before sending the body of the message during the HTTP-Artifact binding if the server do not response.

If the IDP called by the mellon-curl/HTTP-Artifact is an Apache server, the Apache do not support the Expect Header and will be ignored. So the curl will wait for 1 sec (for nothing).

So, to improve performance with the HTTP-Artifact binding, let's have an option to unset the Expect Header of the curl (MellonDisabledCurlExpectLogic Off/On). (for those idp in front of an Apache server)

Disabling the Expect Logic saves an additional network round-trip and is thus
a good idea when the request isn't extremely large and the probability for rejection is low.

/Eric.